### PR TITLE
feat: add user re-selection confirmation in apply.sh

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -170,6 +170,7 @@ main() {
     bootstrap_sops
 
     select_user
+    confirm_or_reselect_user
     apply_home_manager
     apply_wsl_optimizations
 

--- a/docs/USER_CONFIGURATION.md
+++ b/docs/USER_CONFIGURATION.md
@@ -143,6 +143,37 @@ programs.zsh.enable = true;  # If you chose zsh
 
 ## Managing Configuration
 
+### User Re-selection During Setup
+
+During the interactive setup, you'll have an opportunity to confirm or change your user selection before applying the Home Manager configuration:
+
+```bash
+./apply.sh
+
+# ... earlier steps ...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+User Selection Confirmation
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Selected user: naroslife
+
+This user will be used for:
+  • Home Manager configuration
+  • Git configuration
+  • Environment setup
+
+Continue with this user? [Y/n]: n
+
+# You can now re-select a different user
+Available user configurations:
+  - naroslife
+  - enterpriseuser
+Enter username for configuration: enterpriseuser
+```
+
+This allows you to change user selection without restarting the entire setup process.
+
 ### Update Existing Configuration
 
 Re-run the interactive setup:

--- a/lib/setup/user.sh
+++ b/lib/setup/user.sh
@@ -90,6 +90,36 @@ select_user() {
     fi
 }
 
+# Confirm or re-select user before applying configuration
+confirm_or_reselect_user() {
+    if $ASSUME_YES; then
+        log_info "Proceeding with user: $TARGET_USER"
+        return 0
+    fi
+
+    echo
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log_info "User Selection Confirmation"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo
+    echo "Selected user: ${COLOR_GREEN}$TARGET_USER${COLOR_NC}"
+    echo
+    echo "This user will be used for:"
+    echo "  • Home Manager configuration"
+    echo "  • Git configuration"
+    echo "  • Environment setup"
+    echo
+
+    if ask_yes_no "Continue with this user?" y; then
+        return 0
+    else
+        log_info "Re-selecting user..."
+        # Clear TARGET_USER to force re-selection
+        TARGET_USER=""
+        select_user
+    fi
+}
+
 # Run interactive user configuration
 run_user_configuration() {
     # Source the user config module


### PR DESCRIPTION
## Summary

Implements Option 1 from issue #16 analysis, adding a user confirmation/re-selection prompt during the apply.sh workflow.

## Changes

- **Added**: `confirm_or_reselect_user()` function in `lib/setup/user.sh`
- **Updated**: `apply.sh` to call confirmation function before Home Manager application
- **Documented**: New workflow in `docs/USER_CONFIGURATION.md`

## Benefits

- Users can review and change user selection without restarting setup
- Clear confirmation prompt shows what the selection will be used for
- Non-breaking change – existing workflows continue to work
- Bypassed in non-interactive mode (-y flag)

## Testing

Manual testing recommended:

```bash
./apply.sh  # Test interactive mode with confirmation
./apply.sh -y # Test non-interactive mode (should skip confirmation)
./apply.sh -u naroslife # Test with explicit user
```

Resolves #16

---

Generated with [Claude Code](https://claude.ai/code)