### PR TITLE
feat(ci): add MCP servers and restructure skills

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,8 +56,18 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # MCP servers for enhanced capabilities
+          mcp_config: |
+            {
+              "mcpServers": {
+                "context7": {
+                  "command": "npx",
+                  "args": ["-y", "@upstash/context7-mcp@latest"]
+                },
+                "sequential-thinking": {
+                  "command": "npx",
+                  "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+                }
+              }
+            }
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,11 +62,21 @@ jobs:
               "mcpServers": {
                 "context7": {
                   "command": "npx",
-                  "args": ["-y", "@upstash/context7-mcp@latest"]
+                  "args": ["-y", "@upstash/context7-mcp@latest"],
+                  "env": {
+                    "CONTEXT7_API_KEY": "${{ secrets.CONTEXT7_API_KEY }}"
+                  }
                 },
                 "sequential-thinking": {
                   "command": "npx",
                   "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+                },
+                "exa": {
+                  "command": "npx",
+                  "args": ["-y", "exa-mcp-server"],
+                  "env": {
+                    "EXA_API_KEY": "${{ secrets.EXA_API_KEY }}"
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary

- **Add Context7 and Sequential Thinking MCP servers** to the Claude Code Action workflow — gives CI Claude access to live library docs and structured reasoning
- **Restructure skills** into `directory/SKILL.md` format (chezmoi/, cli-tools/, mise-guide/)

Exa MCP omitted (needs API key). Add `EXA_API_KEY` repo secret to enable later.

## Test plan

- [ ] Merge and trigger `@claude` on an issue/PR
- [ ] Verify Context7 tools appear in Claude's tool list
- [ ] Verify skills are loaded from `.claude/skills/`