### PR TITLE
feat(ci): autonomous Claude+Copilot review cycle with auto-merge

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,15 +17,20 @@ jobs:
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR' ||
-         github.event.comment.user.login == 'github-actions[bot]')) ||
+         github.event.comment.user.login == 'github-actions[bot]' ||
+         github.event.comment.user.login == 'copilot[bot]')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'COLLABORATOR')) ||
+         github.event.comment.author_association == 'COLLABORATOR' ||
+         github.event.comment.user.login == 'copilot[bot]' ||
+         github.event.comment.user.login == 'github-actions[bot]')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
-         github.event.review.author_association == 'COLLABORATOR')) ||
+         github.event.review.author_association == 'COLLABORATOR' ||
+         github.event.review.user.login == 'copilot[bot]' ||
+         github.event.review.user.login == 'github-actions[bot]')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         (github.event.issue.author_association == 'OWNER' ||
          github.event.issue.author_association == 'MEMBER' ||

--- a/.github/workflows/migration-orchestrator.yml
+++ b/.github/workflows/migration-orchestrator.yml
@@ -156,7 +156,9 @@ jobs:
 
             **Context**: This is part of the "Migrate dotfiles from Nix/Home Manager to chezmoi+mise" epic. Check other closed PRs in this epic for context on decisions already made.
 
-            **Important**: Read \`CLAUDE.md\` and any architecture docs that exist before starting. Follow the tier classification and tool audit from issue #20.`;
+            **Important**: Read \`CLAUDE.md\` and any architecture docs that exist before starting. Follow the tier classification and tool audit from issue #20.
+
+            **PR labels**: When you open the PR, add the \`epic:nix-migration\` label so the review cycle starts automatically.`;
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-review-cycle.yml
+++ b/.github/workflows/pr-review-cycle.yml
@@ -1,0 +1,61 @@
+name: PR Review Cycle
+
+# Autonomous review cycle: Claude implements → Copilot reviews → Claude fixes →
+# Claude reviews → Copilot fixes → auto-merge. Agents tag each other via comments.
+# Uses ORCHESTRATOR_PAT so comments trigger other workflows.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  start-review-cycle:
+    # Only run on epic PRs opened by Claude (the implementer)
+    if: |
+      contains(toJSON(github.event.pull_request.labels), 'epic:nix-migration') ||
+      github.event.pull_request.user.login == 'claude[bot]' ||
+      github.event.pull_request.user.login == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Start review cycle
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORCHESTRATOR_PAT }}
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+
+            console.log(`Starting review cycle for PR #${prNumber}`);
+
+            // Add tracking label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['review-round-1'],
+            });
+
+            // Tag Copilot to review
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `[review-cycle:round-1] @copilot Please review this PR thoroughly. Check for:
+
+            1. Code quality, correctness, and completeness against the linked issue
+            2. Security concerns (hardcoded secrets, injection risks)
+            3. Missing edge cases or error handling
+            4. Consistency with the project's CLAUDE.md conventions
+            5. Whether acceptance criteria from the issue are fully met
+
+            If you find issues, list them clearly. If everything looks good, approve the PR.
+
+            After your review, tag \`@claude\` to address any findings.`
+            });
+
+            console.log('Tagged @copilot for round 1 review');

--- a/.github/workflows/pr-review-cycle.yml
+++ b/.github/workflows/pr-review-cycle.yml
@@ -12,9 +12,12 @@ jobs:
   start-review-cycle:
     # Only run on epic PRs opened by Claude (the implementer)
     if: |
-      contains(toJSON(github.event.pull_request.labels), 'epic:nix-migration') ||
-      github.event.pull_request.user.login == 'claude[bot]' ||
-      github.event.pull_request.user.login == 'github-actions[bot]'
+      contains(toJSON(github.event.pull_request.labels), 'epic:nix-migration') &&
+      (
+        github.event.pull_request.user.login == 'claude[bot]' ||
+        github.event.pull_request.user.login == 'github-actions[bot]'
+      ) &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/review-handoff.yml
+++ b/.github/workflows/review-handoff.yml
@@ -77,7 +77,7 @@ jobs:
 
                 // Get latest review state per reviewer (sort descending by submitted_at)
                 const latestPerReviewer = new Map();
-                for (const r of reviews.data.sort((a, b) =>
+                for (const r of reviews.data.slice().sort((a, b) =>
                   new Date(b.submitted_at) - new Date(a.submitted_at)
                 )) {
                   if (!latestPerReviewer.has(r.user.login)) {

--- a/.github/workflows/review-handoff.yml
+++ b/.github/workflows/review-handoff.yml
@@ -22,10 +22,11 @@ jobs:
   handoff:
     # Only on epic PRs that are in an active review cycle
     if: |
-      (github.event_name == 'pull_request' &&
+      ((github.event_name == 'pull_request' &&
        contains(toJSON(github.event.pull_request.labels), 'review-round-')) ||
       (github.event_name == 'pull_request_review' &&
-       contains(toJSON(github.event.pull_request.labels), 'review-round-'))
+       contains(toJSON(github.event.pull_request.labels), 'review-round-'))) &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -74,8 +75,20 @@ jobs:
                   pull_number: prNumber,
                 });
 
-                const approvals = reviews.data.filter(r => r.state === 'APPROVED');
-                const uniqueApprovers = new Set(approvals.map(r => r.user.login));
+                // Get latest review state per reviewer (sort descending by submitted_at)
+                const latestPerReviewer = new Map();
+                for (const r of reviews.data.sort((a, b) =>
+                  new Date(b.submitted_at) - new Date(a.submitted_at)
+                )) {
+                  if (!latestPerReviewer.has(r.user.login)) {
+                    latestPerReviewer.set(r.user.login, r.state);
+                  }
+                }
+                const uniqueApprovers = new Set(
+                  [...latestPerReviewer.entries()]
+                    .filter(([, state]) => state === 'APPROVED')
+                    .map(([login]) => login)
+                );
 
                 if (uniqueApprovers.size >= 1 && currentRound >= 2) {
                   // Enough rounds + approval → auto-merge
@@ -187,7 +200,7 @@ jobs:
             // Handle synchronize (new commits pushed — someone fixed something)
             if (context.eventName === 'pull_request') {
               // New commits pushed — tag the other agent to re-review
-              const pusher = pr.user.login;
+              const pusher = context.payload.sender?.login || context.actor || pr.user.login;
               const reviewer = pusher.includes('copilot') ? '@claude' : '@copilot';
 
               // Check if this was triggered by review fixes (not initial PR creation)
@@ -199,15 +212,21 @@ jobs:
                 }
 
                 // Don't duplicate if we already commented for this round
-                const comments = await github.rest.issues.listComments({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                  per_page: 10,
-                });
+                const allComments = await github.paginate(
+                  github.rest.issues.listComments,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    per_page: 100,
+                  }
+                );
 
-                const lastComment = comments.data[comments.data.length - 1];
-                if (lastComment && lastComment.body.includes(`review-cycle:round-${nextRound}`)) {
+                const roundAlreadyTriggered = allComments.some(c =>
+                  typeof c.body === 'string' &&
+                  c.body.includes(`review-cycle:round-${nextRound}`)
+                );
+                if (roundAlreadyTriggered) {
                   console.log(`Round ${nextRound} already triggered. Skipping.`);
                   return;
                 }

--- a/.github/workflows/review-handoff.yml
+++ b/.github/workflows/review-handoff.yml
@@ -1,0 +1,232 @@
+name: Review Handoff
+
+# Manages the back-and-forth between Claude and Copilot during review.
+# When one agent finishes (pushes commits or leaves a comment), this workflow
+# tags the other agent to continue the cycle.
+#
+# Flow:
+#   Round 1: Copilot reviews (triggered by pr-review-cycle.yml)
+#   Round 2: Claude addresses Copilot's feedback, then does own review
+#   Round 3: Copilot implements Claude's feedback (or argues back)
+#   Final:   Auto-merge if approved, or escalate after max rounds
+
+on:
+  # Triggered when either agent pushes fixes
+  pull_request:
+    types: [synchronize]
+  # Triggered when an agent leaves a review
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  handoff:
+    # Only on epic PRs that are in an active review cycle
+    if: |
+      (github.event_name == 'pull_request' &&
+       contains(toJSON(github.event.pull_request.labels), 'review-round-')) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(toJSON(github.event.pull_request.labels), 'review-round-'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Determine review state and hand off
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORCHESTRATOR_PAT }}
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+
+            // Get current labels
+            const labels = pr.labels.map(l => l.name);
+            const roundLabels = labels.filter(l => l.startsWith('review-round-'));
+            const currentRound = roundLabels.length > 0
+              ? Math.max(...roundLabels.map(l => parseInt(l.split('-')[2])))
+              : 0;
+
+            const MAX_ROUNDS = 3;
+
+            console.log(`PR #${prNumber}, current round: ${currentRound}, event: ${context.eventName}`);
+
+            // Check if already merged or has auto-merge label
+            if (labels.includes('auto-merged') || pr.merged) {
+              console.log('PR already merged. Skipping.');
+              return;
+            }
+
+            // Handle review submission
+            if (context.eventName === 'pull_request_review') {
+              const review = context.payload.review;
+              const reviewer = review.user.login;
+              const state = review.state; // APPROVED, CHANGES_REQUESTED, COMMENTED
+
+              console.log(`Review by ${reviewer}: ${state}`);
+
+              if (state === 'APPROVED') {
+                // Check if we have enough approvals for auto-merge
+                const reviews = await github.rest.pulls.listReviews({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+
+                const approvals = reviews.data.filter(r => r.state === 'APPROVED');
+                const uniqueApprovers = new Set(approvals.map(r => r.user.login));
+
+                if (uniqueApprovers.size >= 1 && currentRound >= 2) {
+                  // Enough rounds + approval → auto-merge
+                  console.log('Sufficient approvals after review cycle. Auto-merging...');
+
+                  // Final check: ask Claude to create follow-up tickets if needed
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `[review-cycle:final] @claude This PR has been approved after ${currentRound} review rounds.
+
+            Before merging:
+            1. Check if there are any remaining concerns that should be tracked as follow-up issues
+            2. If yes, create GitHub issues with label \`tech-debt\` for any deferred items
+            3. Then merge this PR using \`gh pr merge ${prNumber} --squash --delete-branch\`
+            4. Comment "MERGED" when done`
+                  });
+
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    labels: ['ready-to-merge'],
+                  });
+                  return;
+                }
+
+                if (currentRound < 2) {
+                  // Approved early — still do a cross-review
+                  const nextRound = currentRound + 1;
+                  const nextAgent = reviewer.includes('copilot') ? '@claude' : '@copilot';
+
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    labels: [`review-round-${nextRound}`],
+                  });
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `[review-cycle:round-${nextRound}] ${nextAgent} The previous reviewer approved, but let's do a cross-review for quality.
+
+            Please review this PR independently. Focus on:
+            1. Anything the previous reviewer might have missed
+            2. Architectural concerns or patterns that could be improved
+            3. Whether this aligns with the migration epic goals
+
+            If you agree it's good, approve. If you find issues, request changes.`
+                  });
+                  return;
+                }
+              }
+
+              if (state === 'CHANGES_REQUESTED') {
+                // Determine who should fix
+                const nextRound = currentRound + 1;
+
+                if (nextRound > MAX_ROUNDS) {
+                  // Max rounds reached — merge with tech debt
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `[review-cycle:max-rounds] @claude Maximum review rounds (${MAX_ROUNDS}) reached.
+
+            1. Create a \`tech-debt\` issue for any unresolved review findings
+            2. Merge this PR as-is: \`gh pr merge ${prNumber} --squash --delete-branch\`
+            3. Comment "MERGED" when done`
+                  });
+
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    labels: ['ready-to-merge'],
+                  });
+                  return;
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: [`review-round-${nextRound}`],
+                });
+
+                // Tag the implementer to fix (alternate between agents)
+                const fixer = reviewer.includes('copilot') ? '@claude' : '@copilot';
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: `[review-cycle:round-${nextRound}] ${fixer} The reviewer requested changes. Please:
+
+            1. Address each finding from the review above
+            2. Push your fixes to this branch
+            3. If you disagree with a finding, explain why in a comment — constructive pushback is welcome
+            4. After pushing fixes, tag the other agent for re-review`
+                });
+                return;
+              }
+            }
+
+            // Handle synchronize (new commits pushed — someone fixed something)
+            if (context.eventName === 'pull_request') {
+              // New commits pushed — tag the other agent to re-review
+              const pusher = pr.user.login;
+              const reviewer = pusher.includes('copilot') ? '@claude' : '@copilot';
+
+              // Check if this was triggered by review fixes (not initial PR creation)
+              if (currentRound >= 1) {
+                const nextRound = currentRound + 1;
+
+                if (nextRound > MAX_ROUNDS) {
+                  return; // Already handled above
+                }
+
+                // Don't duplicate if we already commented for this round
+                const comments = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 10,
+                });
+
+                const lastComment = comments.data[comments.data.length - 1];
+                if (lastComment && lastComment.body.includes(`review-cycle:round-${nextRound}`)) {
+                  console.log(`Round ${nextRound} already triggered. Skipping.`);
+                  return;
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: [`review-round-${nextRound}`],
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: `[review-cycle:round-${nextRound}] ${reviewer} Fixes have been pushed. Please re-review the changes.
+
+            Focus on whether the previous findings have been adequately addressed.
+            Approve if satisfied, or request further changes if needed.`
+                });
+              }
+            }

--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -1,0 +1,166 @@
+name: Stuck Check
+
+# Runs hourly to detect stalled PRs/issues in the migration epic.
+# Nudges agents forward if no activity for >2 hours.
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Every hour
+  workflow_dispatch: {}   # Manual trigger
+
+jobs:
+  check-stuck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Check for stuck work
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORCHESTRATOR_PAT }}
+          script: |
+            const STALE_HOURS = 2;
+            const now = new Date();
+            const staleThreshold = new Date(now - STALE_HOURS * 60 * 60 * 1000);
+
+            console.log(`Checking for items stale since ${staleThreshold.toISOString()}`);
+
+            // Check open PRs with review-round labels
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 20,
+            });
+
+            for (const pr of prs.data) {
+              const hasReviewLabel = pr.labels.some(l => l.name.startsWith('review-round-'));
+              const hasReadyLabel = pr.labels.some(l => l.name === 'ready-to-merge');
+
+              if (!hasReviewLabel && !hasReadyLabel) continue;
+
+              const updatedAt = new Date(pr.updated_at);
+              if (updatedAt > staleThreshold) continue;
+
+              const hoursSinceUpdate = Math.round((now - updatedAt) / (60 * 60 * 1000));
+
+              // Check if we already nudged recently
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 5,
+              });
+
+              const recentNudge = comments.data.some(c =>
+                c.body.includes('[stuck-check]') &&
+                new Date(c.created_at) > staleThreshold
+              );
+
+              if (recentNudge) {
+                console.log(`PR #${pr.number} already nudged recently. Skipping.`);
+                continue;
+              }
+
+              console.log(`PR #${pr.number} stale for ${hoursSinceUpdate}h`);
+
+              if (hasReadyLabel) {
+                // Should have been merged — nudge Claude
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `[stuck-check] @claude This PR has been marked \`ready-to-merge\` but hasn't been merged yet (${hoursSinceUpdate}h stale). Please merge it now: \`gh pr merge ${pr.number} --squash --delete-branch\``
+                });
+              } else {
+                // Review cycle stalled — figure out who's turn it is
+                const lastComment = comments.data[comments.data.length - 1];
+                const waitingFor = lastComment?.body?.includes('@copilot') ? '@copilot' : '@claude';
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `[stuck-check] ${waitingFor} This PR's review cycle has been inactive for ${hoursSinceUpdate} hours. Please continue — review or address the pending feedback.`
+                });
+              }
+            }
+
+            // Check issues with in-progress label but no PR
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'in-progress,epic:nix-migration',
+              state: 'open',
+              per_page: 20,
+            });
+
+            for (const issue of issues.data) {
+              if (issue.pull_request) continue; // skip PRs
+
+              const updatedAt = new Date(issue.updated_at);
+              if (updatedAt > staleThreshold) continue;
+
+              const hoursSinceUpdate = Math.round((now - updatedAt) / (60 * 60 * 1000));
+
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 5,
+              });
+
+              const recentNudge = comments.data.some(c =>
+                c.body.includes('[stuck-check]') &&
+                new Date(c.created_at) > staleThreshold
+              );
+
+              if (recentNudge) continue;
+
+              console.log(`Issue #${issue.number} in-progress but stale for ${hoursSinceUpdate}h`);
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `[stuck-check] @claude This issue has been in-progress for ${hoursSinceUpdate} hours without a PR. Please continue implementation or report what's blocking you.`
+              });
+            }
+
+            // Check if orchestrator should trigger next issues
+            // (in case a PR was merged but orchestrator didn't fire)
+            const epicIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'epic:nix-migration',
+              state: 'open',
+              per_page: 50,
+            });
+
+            const openWithoutProgress = epicIssues.data.filter(i =>
+              !i.pull_request &&
+              !i.labels.some(l => l.name === 'in-progress')
+            );
+
+            if (openWithoutProgress.length > 0) {
+              console.log(`${openWithoutProgress.length} epic issues not yet started. Triggering orchestrator check...`);
+
+              // Trigger orchestrator via workflow_dispatch
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'migration-orchestrator.yml',
+                  ref: 'main',
+                  inputs: { trigger_all_unblocked: 'true' },
+                });
+                console.log('Orchestrator triggered to check for unblocked issues');
+              } catch (e) {
+                console.log(`Could not trigger orchestrator: ${e.message}`);
+              }
+            }
+
+            console.log('Stuck check complete.');

--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -47,12 +47,13 @@ jobs:
 
               const hoursSinceUpdate = Math.round((now - updatedAt) / (60 * 60 * 1000));
 
-              // Check if we already nudged recently
+              // Check if we already nudged recently (use since: to get only recent comments)
               const comments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                per_page: 5,
+                since: staleThreshold.toISOString(),
+                per_page: 20,
               });
 
               const recentNudge = comments.data.some(c =>
@@ -76,9 +77,10 @@ jobs:
                   body: `[stuck-check] @claude This PR has been marked \`ready-to-merge\` but hasn't been merged yet (${hoursSinceUpdate}h stale). Please merge it now: \`gh pr merge ${pr.number} --squash --delete-branch\``
                 });
               } else {
-                // Review cycle stalled — figure out who's turn it is
-                const lastComment = comments.data[comments.data.length - 1];
-                const waitingFor = lastComment?.body?.includes('@copilot') ? '@copilot' : '@claude';
+                // Review cycle stalled — derive who's turn from round label (odd=copilot, even=claude)
+                const currentRoundLabel = pr.labels.find(l => l.name.startsWith('review-round-'));
+                const roundNum = currentRoundLabel ? parseInt(currentRoundLabel.name.split('-')[2]) : 1;
+                const waitingFor = roundNum % 2 === 1 ? '@copilot' : '@claude';
 
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
@@ -110,7 +112,8 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                per_page: 5,
+                since: staleThreshold.toISOString(),
+                per_page: 20,
               });
 
               const recentNudge = comments.data.some(c =>
@@ -140,26 +143,41 @@ jobs:
               per_page: 50,
             });
 
-            const openWithoutProgress = epicIssues.data.filter(i =>
-              !i.pull_request &&
-              !i.labels.some(l => l.name === 'in-progress')
-            );
+            const dispatchCandidates = epicIssues.data.filter(i => {
+              if (i.pull_request) return false;
+              const labelNames = i.labels.map(l => l.name);
+              return !labelNames.includes('in-progress') && !labelNames.includes('blocked');
+            });
 
-            if (openWithoutProgress.length > 0) {
-              console.log(`${openWithoutProgress.length} epic issues not yet started. Triggering orchestrator check...`);
+            if (dispatchCandidates.length > 0) {
+              const orchestratorRuns = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'migration-orchestrator.yml',
+                per_page: 10,
+              });
 
-              // Trigger orchestrator via workflow_dispatch
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'migration-orchestrator.yml',
-                  ref: 'main',
-                  inputs: { trigger_all_unblocked: 'true' },
-                });
-                console.log('Orchestrator triggered to check for unblocked issues');
-              } catch (e) {
-                console.log(`Could not trigger orchestrator: ${e.message}`);
+              const recentDispatchThreshold = new Date(now.getTime() - 60 * 60 * 1000);
+              const recentOrchestratorRun = orchestratorRuns.data.workflow_runs.some(run =>
+                new Date(run.created_at) > recentDispatchThreshold
+              );
+
+              if (recentOrchestratorRun) {
+                console.log('Skipping orchestrator dispatch — already ran within the last hour.');
+              } else {
+                console.log(`${dispatchCandidates.length} actionable epic issues. Triggering orchestrator...`);
+                try {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'migration-orchestrator.yml',
+                    ref: 'main',
+                    inputs: { trigger_all_unblocked: 'true' },
+                  });
+                  console.log('Orchestrator triggered to check for unblocked issues');
+                } catch (e) {
+                  console.log(`Could not trigger orchestrator: ${e.message}`);
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

Fully autonomous review pipeline — no human review or merge needed.

### New Workflows

| Workflow | Trigger | Purpose |
|----------|---------|---------|
| `pr-review-cycle.yml` | PR opened | Tags `@copilot` to start round 1 review |
| `review-handoff.yml` | PR review submitted / commits pushed | Manages agent handoff — tags the other agent after each round |
| `stuck-check.yml` | Hourly cron | Nudges stale PRs/issues, triggers orchestrator for unblocked work |

### Review Flow

```
Orchestrator triggers @claude on issue
  → Claude implements, opens PR with epic:nix-migration label
    → pr-review-cycle tags @copilot for review (round 1)
      → Copilot reviews
        → review-handoff tags @claude to address findings (round 2)
          → Claude fixes + does own review
            → review-handoff tags @copilot to implement/argue (round 3)
              → After approval or max rounds → auto-merge
                → Orchestrator triggers next unblocked issues
```

### Safeguards

- Max 3 review rounds before auto-merge with tech-debt ticket
- Hourly stuck-check nudges stale items (>2h no activity)
- Both agents can push back with counter-arguments
- Claude creates follow-up tickets for deferred items before merging

### Changes to existing workflows

- `claude.yml`: Accepts `@claude` from `copilot[bot]` and `github-actions[bot]`
- `migration-orchestrator.yml`: Instructs Claude to add `epic:nix-migration` label to PRs

## Test plan

- [x] Merge this PR
- [ ] Close and clean up existing PR #42
- [ ] Run orchestrator on issue #20
- [ ] Verify: Claude implements → PR opened → Copilot tagged → review cycle runs → auto-merge