### PR TITLE
fix(ci): don't skip approvals due to staleness check

### DIFF
--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -178,10 +178,11 @@ jobs:
               const currentRound = Math.max(...roundLabels.map(l => parseInt(l.split('-')[2])));
 
               const updatedAt = new Date(pr.updated_at);
-              if (updatedAt > staleThreshold) {
-                console.log(`Last activity ${updatedAt.toISOString()} — within staleness window. Skipping.`);
-                continue;
-              }
+              const isFresh = updatedAt > staleThreshold;
+              // Note: do NOT skip here on staleness. Approvals must be acted on
+              // immediately, and round-advance comments are de-duplicated by
+              // `nextRoundTriggered` below. Staleness only gates the "nudge an
+              // already-triggered round" branch (line ~330).
 
               // Gather all comments (issue_comments) and formal reviews and commits.
               const comments = await github.paginate(
@@ -324,7 +325,13 @@ jobs:
               );
 
               if (nextRoundTriggered) {
-                // Just nudge whoever the round expects.
+                // Already prompted for this round — only nudge when truly stale,
+                // otherwise we'd post a nudge every 15 min while the agent is
+                // still working.
+                if (isFresh) {
+                  console.log(`Round ${nextRound} already triggered and PR is fresh (${ageMin}m). No nudge needed.`);
+                  continue;
+                }
                 const nudgeAgent = (nextRound % 2 === 1) ? '@copilot' : '@claude';
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,

--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -182,7 +182,7 @@ jobs:
               // Note: do NOT skip here on staleness. Approvals must be acted on
               // immediately, and round-advance comments are de-duplicated by
               // `nextRoundTriggered` below. Staleness only gates the "nudge an
-              // already-triggered round" branch (line ~330).
+              // already-triggered round" branch in the `nextRoundTriggered` logic.
 
               // Gather all comments (issue_comments) and formal reviews and commits.
               const comments = await github.paginate(
@@ -329,7 +329,11 @@ jobs:
                 // otherwise we'd post a nudge every 15 min while the agent is
                 // still working.
                 if (isFresh) {
-                  console.log(`Round ${nextRound} already triggered and PR is fresh (${ageMin}m). No nudge needed.`);
+                  const updatedAgeMin = Math.round((Date.now() - Date.parse(pr.updated_at)) / 60000);
+                  console.log(
+                    `Round ${nextRound} already triggered and PR is fresh ` +
+                    `(${updatedAgeMin}m since updated_at; ${ageMin}m since last meaningful event). No nudge needed.`
+                  );
                   continue;
                 }
                 const nudgeAgent = (nextRound % 2 === 1) ? '@copilot' : '@claude';


### PR DESCRIPTION
## Why

Discovered while watching #57: Claude posted **\"LGTM — ready to merge\"** at 11:02:34 UTC. The next \`Stuck Check\` tick at 11:07:08 saw activity within the 12-min staleness window, hit the early \`if (updatedAt > staleThreshold) continue\` skip, and never evaluated the approval — leaving the PR sitting until the *next* tick when it would have aged past the window. That added ~15 min of needless delay and would do the same on every approval.

## Fix

- Drop the early staleness skip; compute \`isFresh\` instead.
- Approval-detection, max-rounds escalation, and new-round handoff always run. They are de-duplicated by:
  - \`nextRoundTriggered\` check (avoids re-posting a round-N prompt)
  - \`ready-to-merge\` label being idempotent
- Staleness now gates only the nudge path: if a round was already prompted, only post a nudge when the cycle has actually idled past the threshold (otherwise we'd nudge every 15 min while the agent is still working).