### PR TITLE
fix(ci): merge ready-to-merge PRs in the same tick as approval

### DIFF
--- a/.github/workflows/review-handoff.yml
+++ b/.github/workflows/review-handoff.yml
@@ -166,6 +166,7 @@ jobs:
             };
 
             const markReadyToMerge = async () => {
+              let labeled = false;
               try {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
@@ -173,8 +174,26 @@ jobs:
                   issue_number: prNumber,
                   labels: ['ready-to-merge'],
                 });
+                labeled = true;
               } catch (e) {
                 console.log(`Could not add ready-to-merge label: ${e.message}`);
+                // Re-check: maybe the label was already present (e.g. prior
+                // handoff). If so, we still want stuck-check to run.
+                try {
+                  const cur = (await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                  })).data;
+                  labeled = cur.labels.some(l => (l.name || l) === 'ready-to-merge');
+                } catch (e2) {
+                  console.log(`Could not re-check labels: ${e2.message}`);
+                }
+              }
+
+              if (!labeled) {
+                console.log('ready-to-merge not applied — skipping stuck-check dispatch.');
+                return;
               }
 
               // Dispatch stuck-check immediately so the merge fires in seconds,

--- a/.github/workflows/review-handoff.yml
+++ b/.github/workflows/review-handoff.yml
@@ -98,6 +98,12 @@ jobs:
               return;
             }
 
+            // Escape hatch — if a human has been pulled in, pause automation.
+            if (labels.includes('needs-human-review')) {
+              console.log('PR flagged for human review. Skipping handoff.');
+              return;
+            }
+
             // ---- Helpers ----------------------------------------------------
 
             const COPILOT_LOGINS = new Set(['Copilot', 'copilot-swe-agent', 'copilot[bot]']);
@@ -144,6 +150,19 @@ jobs:
                 issue_number: prNumber,
                 body,
               });
+            };
+
+            const flagForHumanReview = async () => {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: ['needs-human-review'],
+                });
+              } catch (e) {
+                console.log(`Could not add needs-human-review label: ${e.message}`);
+              }
             };
 
             const markReadyToMerge = async () => {
@@ -205,12 +224,14 @@ jobs:
                 // Copilot finished a review but cycle still has rounds: tag Claude.
                 const nextRound = currentRound + 1;
                 if (nextRound > MAX_ROUNDS) {
-                  console.log('Max rounds reached. Marking ready-to-merge with tech debt.');
-                  await markReadyToMerge();
+                  console.log('Max rounds reached without approval. Flagging for human review.');
+                  await flagForHumanReview();
                   await postComment(
-                    `[review-cycle:max-rounds] Max review rounds (${MAX_ROUNDS}) reached. ` +
-                    `Marking \`ready-to-merge\`; stuck-check will merge on its next tick. ` +
-                    `Any unresolved findings should be tracked as follow-up \`tech-debt\` issues.`
+                    `[review-cycle:max-rounds] @${context.repo.owner} Max review rounds (${MAX_ROUNDS}) reached without approval. ` +
+                    `The automated Claude↔Copilot cycle could not converge. Please review manually and either:\n\n` +
+                    `1. Merge if acceptable (optionally file \`tech-debt\` follow-ups), or\n` +
+                    `2. Post further feedback and remove \`needs-human-review\` to resume the automated cycle, or\n` +
+                    `3. Close this PR.`
                   );
                   return;
                 }
@@ -278,10 +299,11 @@ jobs:
                 const nextRound = currentRound + 1;
 
                 if (nextRound > MAX_ROUNDS) {
-                  await markReadyToMerge();
+                  console.log('Max rounds reached on CHANGES_REQUESTED. Flagging for human review.');
+                  await flagForHumanReview();
                   await postComment(
-                    `[review-cycle:max-rounds] Max review rounds (${MAX_ROUNDS}) reached. ` +
-                    `Marking \`ready-to-merge\`; stuck-check will merge on its next tick.`
+                    `[review-cycle:max-rounds] @${context.repo.owner} Max review rounds (${MAX_ROUNDS}) reached with changes still requested. ` +
+                    `Human review needed — the agents couldn't converge.`
                   );
                   return;
                 }

--- a/.github/workflows/review-handoff.yml
+++ b/.github/workflows/review-handoff.yml
@@ -157,6 +157,20 @@ jobs:
               } catch (e) {
                 console.log(`Could not add ready-to-merge label: ${e.message}`);
               }
+
+              // Dispatch stuck-check immediately so the merge fires in seconds,
+              // not up to 15 min later on the next scheduled tick.
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'stuck-check.yml',
+                  ref: 'main',
+                });
+                console.log('Dispatched stuck-check to merge ready-to-merge PR immediately.');
+              } catch (e) {
+                console.log(`Could not dispatch stuck-check: ${e.message}`);
+              }
             };
 
             // ---- issue_comment branch (Copilot's reviews land here) --------

--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -173,6 +173,14 @@ jobs:
                 continue;
               }
 
+              // Human-review escape hatch — if a PR has been flagged for human
+              // review (e.g. by hitting max rounds without approval), pause
+              // the automated cycle until the label is removed.
+              if (labels.includes('needs-human-review')) {
+                console.log('PR flagged for human review. Skipping automated actions.');
+                continue;
+              }
+
               // ---- READY-TO-MERGE: perform the merge ourselves ----
               if (labels.includes('ready-to-merge')) {
                 console.log('Has ready-to-merge label. Attempting merge.');
@@ -312,21 +320,30 @@ jobs:
               const candidateRound = currentRound + 1;
 
               if (candidateRound > MAX_ROUNDS) {
-                console.log(`Already at MAX_ROUNDS (${MAX_ROUNDS}). Marking ready-to-merge and attempting merge.`);
+                // Max rounds without approval => STOP auto-merging, ping human.
+                // The agents couldn't converge; the user must decide.
+                if (labels.includes('needs-human-review')) {
+                  console.log(`Already flagged for human review. Skipping.`);
+                  continue;
+                }
+                console.log(`Max rounds (${MAX_ROUNDS}) reached without approval. Flagging for human review.`);
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  labels: ['ready-to-merge'],
-                });
+                  labels: ['needs-human-review'],
+                }).catch((e) => console.log(`Could not add label: ${e.message}`));
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  body: `[stuck-check] Max review rounds (${MAX_ROUNDS}) reached without explicit approval. ` +
-                        `Marking \`ready-to-merge\` and attempting merge now. Track unresolved findings as \`tech-debt\` issues.`,
+                  body: `[stuck-check] @${context.repo.owner} Max review rounds (${MAX_ROUNDS}) reached without explicit approval. ` +
+                        `The Claude↔Copilot cycle could not converge on this PR. Human review is required — please either:\n\n` +
+                        `1. Manually review and merge if you're satisfied, or\n` +
+                        `2. Post further feedback and remove the \`needs-human-review\` label to re-enter the automated cycle, or\n` +
+                        `3. Close this PR if the approach isn't right.\n\n` +
+                        `Automated cycle is paused until this label is removed.`,
                 });
-                await performMerge(pr);
                 continue;
               }
 

--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -59,6 +59,89 @@ jobs:
 
             console.log(`Tick @ ${now.toISOString()} — staleness threshold ${STALE_MINUTES}m`);
 
+            // Perform the actual merge + cleanup for a PR that's ready-to-merge.
+            // Used by both (a) the ready-to-merge-label branch at loop top and
+            // (b) the approval/max-rounds branches below, so the merge fires in
+            // the SAME tick as state transition (no 15-min gap).
+            //
+            // Returns 'merged' | 'deferred' | 'conflicts' | 'failed'.
+            async function performMerge(pr) {
+              const prNumber = pr.number;
+
+              if (pr.mergeable === null) {
+                console.log(`PR #${prNumber}: mergeability still computing. Will retry next tick.`);
+                return 'deferred';
+              }
+
+              if (pr.mergeable === false) {
+                console.log(`PR #${prNumber}: not mergeable (conflicts?). Posting fix-it comment.`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: `[stuck-check] @claude This PR is marked \`ready-to-merge\` but has merge conflicts. ` +
+                        `Please rebase against \`main\` and resolve conflicts.`,
+                });
+                return 'conflicts';
+              }
+
+              try {
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  merge_method: 'squash',
+                });
+                console.log(`Merged PR #${prNumber}.`);
+
+                // Delete the source branch (best-effort).
+                try {
+                  await github.rest.git.deleteRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `heads/${pr.head.ref}`,
+                  });
+                } catch (e) {
+                  console.log(`Could not delete branch: ${e.message}`);
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: ['auto-merged'],
+                }).catch(() => {});
+
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: 'ready-to-merge',
+                }).catch(() => {});
+
+                // Fan out to next unblocked issues.
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'migration-orchestrator.yml',
+                  ref: 'main',
+                  inputs: { trigger_all_unblocked: 'true' },
+                });
+                console.log(`Dispatched migration-orchestrator after merging #${prNumber}.`);
+                return 'merged';
+              } catch (e) {
+                console.log(`PR #${prNumber}: merge failed: ${e.message}`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: `[stuck-check] @claude Merge attempt failed: \`${e.message}\`. ` +
+                        `Please investigate (CI red? branch protection?) and fix.`,
+                });
+                return 'failed';
+              }
+            }
+
             // ---------- 1) Drive each open epic PR ----------
             const prs = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -93,79 +176,7 @@ jobs:
               // ---- READY-TO-MERGE: perform the merge ourselves ----
               if (labels.includes('ready-to-merge')) {
                 console.log('Has ready-to-merge label. Attempting merge.');
-
-                // mergeable can be null while GitHub is still computing it —
-                // skip and re-check next tick rather than risking a bad merge.
-                if (pr.mergeable === null) {
-                  console.log('Mergeability still computing. Will retry next tick.');
-                  continue;
-                }
-
-                if (pr.mergeable === false) {
-                  console.log('PR not mergeable (conflicts?). Posting fix-it comment.');
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    body: `[stuck-check] @claude This PR is marked \`ready-to-merge\` but has merge conflicts. ` +
-                          `Please rebase against \`main\` and resolve conflicts.`,
-                  });
-                  continue;
-                }
-
-                try {
-                  await github.rest.pulls.merge({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: prNumber,
-                    merge_method: 'squash',
-                  });
-                  console.log(`Merged PR #${prNumber}.`);
-
-                  // Delete the source branch (best-effort).
-                  try {
-                    await github.rest.git.deleteRef({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      ref: `heads/${pr.head.ref}`,
-                    });
-                  } catch (e) {
-                    console.log(`Could not delete branch: ${e.message}`);
-                  }
-
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    labels: ['auto-merged'],
-                  });
-
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    name: 'ready-to-merge',
-                  }).catch(() => {});
-
-                  // Fan out to next unblocked issues.
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: 'migration-orchestrator.yml',
-                    ref: 'main',
-                    inputs: { trigger_all_unblocked: 'true' },
-                  });
-                  console.log('Dispatched migration-orchestrator.');
-                } catch (e) {
-                  console.log(`Merge failed: ${e.message}`);
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    body: `[stuck-check] @claude Merge attempt failed: \`${e.message}\`. ` +
-                          `Please investigate (CI red? branch protection?) and fix.`,
-                  });
-                }
+                await performMerge(pr);
                 continue;
               }
 
@@ -261,7 +272,7 @@ jobs:
               );
 
               if (approvedRecently && currentRound >= 2) {
-                console.log('Approval detected after >= round 2. Marking ready-to-merge.');
+                console.log('Approval detected after >= round 2. Marking ready-to-merge and attempting merge.');
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -273,8 +284,9 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: prNumber,
                   body: `[stuck-check] Approval detected after ${currentRound} review rounds. ` +
-                        `Marking \`ready-to-merge\`; merge will run on the next tick.`,
+                        `Marking \`ready-to-merge\` and attempting merge now.`,
                 });
+                await performMerge(pr);
                 continue;
               }
 
@@ -300,7 +312,7 @@ jobs:
               const candidateRound = currentRound + 1;
 
               if (candidateRound > MAX_ROUNDS) {
-                console.log(`Already at MAX_ROUNDS (${MAX_ROUNDS}). Marking ready-to-merge.`);
+                console.log(`Already at MAX_ROUNDS (${MAX_ROUNDS}). Marking ready-to-merge and attempting merge.`);
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -312,8 +324,9 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: prNumber,
                   body: `[stuck-check] Max review rounds (${MAX_ROUNDS}) reached without explicit approval. ` +
-                        `Marking \`ready-to-merge\`. Track unresolved findings as \`tech-debt\` issues.`,
+                        `Marking \`ready-to-merge\` and attempting merge now. Track unresolved findings as \`tech-debt\` issues.`,
                 });
+                await performMerge(pr);
                 continue;
               }
 

--- a/.github/workflows/stuck-check.yml
+++ b/.github/workflows/stuck-check.yml
@@ -27,6 +27,15 @@ on:
     - cron: '*/15 * * * *'  # Every 15 minutes
   workflow_dispatch: {}
 
+# Serialize runs so the new immediate-dispatch (from review-handoff) can't
+# race the scheduled tick: two overlapping runs on the same PR would have
+# the loser hit an "already merged" error and post a spurious failure
+# comment. cancel-in-progress:false means queued runs wait rather than
+# clobber an in-progress merge.
+concurrency:
+  group: stuck-check
+  cancel-in-progress: false
+
 jobs:
   drive-cycle:
     runs-on: ubuntu-latest
@@ -110,14 +119,18 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: prNumber,
                   labels: ['auto-merged'],
-                }).catch(() => {});
+                }).catch((e) => {
+                  console.log(`Could not add auto-merged label to PR #${prNumber}: ${e.message}`);
+                });
 
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
                   name: 'ready-to-merge',
-                }).catch(() => {});
+                }).catch((e) => {
+                  console.log(`Could not remove ready-to-merge label from PR #${prNumber}: ${e.message}`);
+                });
 
                 // Fan out to next unblocked issues.
                 await github.rest.actions.createWorkflowDispatch({
@@ -130,6 +143,33 @@ jobs:
                 console.log(`Dispatched migration-orchestrator after merging #${prNumber}.`);
                 return 'merged';
               } catch (e) {
+                // Race tolerance: re-fetch the PR to distinguish "genuinely
+                // failed" from "another run (e.g. a concurrent
+                // workflow_dispatch fired by review-handoff) already merged
+                // this PR". Concurrency-group serializes most of this, but
+                // API-level retries / mid-flight races are still possible.
+                try {
+                  const latest = (await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber,
+                  })).data;
+                  if (latest.merged) {
+                    console.log(`PR #${prNumber}: merge API errored but PR is already merged. Treating as success.`);
+                    await github.rest.issues.addLabels({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: prNumber,
+                      labels: ['auto-merged'],
+                    }).catch((err) => {
+                      console.log(`Could not add auto-merged label to PR #${prNumber}: ${err.message}`);
+                    });
+                    return 'merged';
+                  }
+                } catch (e2) {
+                  console.log(`PR #${prNumber}: could not re-check merged state: ${e2.message}`);
+                }
+
                 console.log(`PR #${prNumber}: merge failed: ${e.message}`);
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,


### PR DESCRIPTION
## Why

Approval → merge was split across two stuck-check ticks, adding up to 15 min delay:
- tick N: detects approval, adds \`ready-to-merge\` label, \`continue\`s
- tick N+1: sees label, actually merges

## Fix

- Extract the merge logic (conflicts/null-mergeable/success/failure handling) into \`performMerge(pr)\`.
- Approval-detected and max-rounds branches now call \`performMerge\` inline after labeling, so the merge runs in the SAME tick.
- The existing ready-to-merge-label branch at the top of the loop remains as a fallback (for PRs labeled out-of-band, e.g. by review-handoff event).
- \`review-handoff.markReadyToMerge\` now also dispatches \`stuck-check.yml\` immediately after labeling, so event-driven approvals merge within seconds instead of waiting for the next scheduled tick.

No behaviour change in the unhappy path (conflicts, failed merges, non-approved rounds).